### PR TITLE
Fix: Display error message if wallet connection fails

### DIFF
--- a/src/components/sections/Marketplace.vue
+++ b/src/components/sections/Marketplace.vue
@@ -124,7 +124,7 @@ export default {
   },
   mounted() {
     this.refresh();
-    this.syncWallet();
+    this.syncWallet({ $toast: this.$toast });
     this.$nextTick(function () {
       window.addEventListener("resize", this.getWindowWidth);
 

--- a/src/components/sections/MyAssets.vue
+++ b/src/components/sections/MyAssets.vue
@@ -106,7 +106,7 @@ export default {
   },
   mounted() {
     this.refresh();
-    this.syncWallet();
+    this.syncWallet({ $toast: this.$toast });
   },
   watch: {
     $route: "refresh",

--- a/src/components/sections/NewProposal.vue
+++ b/src/components/sections/NewProposal.vue
@@ -128,7 +128,7 @@ export default {
   },
   mounted() {
     this.refresh({ assetId: this.assetId });
-    this.syncWallet();
+    this.syncWallet({ $toast: this.$toast });
   },
 };
 </script>

--- a/src/components/sections/Proposal.vue
+++ b/src/components/sections/Proposal.vue
@@ -248,7 +248,7 @@ export default {
   },
   mounted() {
     this.refresh({ assetId: this.assetId });
-    this.syncWallet();
+    this.syncWallet({ $toast: this.$toast });
   },
   created() {
     this.setTimeRemainingCountdown();

--- a/src/components/sections/Swap.vue
+++ b/src/components/sections/Swap.vue
@@ -235,7 +235,7 @@ export default {
     },
   },
   created() {
-    this.sync();
+    this.sync({ $toast: this.$toast });
   },
 };
 </script>

--- a/src/components/sections/Voting.vue
+++ b/src/components/sections/Voting.vue
@@ -370,7 +370,7 @@ export default {
   },
   mounted() {
     this.refresh({ assetId: this.assetId });
-    this.syncWallet();
+    this.syncWallet({ $toast: this.$toast });
   },
 };
 </script>

--- a/src/components/views/address/SignerAddress.vue
+++ b/src/components/views/address/SignerAddress.vue
@@ -42,7 +42,7 @@ export default {
       sync: "syncWallet",
     }),
     onClick() {
-      this.sync();
+      this.sync({ $toast: this.$toast });
       this.$toast.show("Syncing wallet...");
     },
   },

--- a/src/components/views/address/SignerAddress.vue
+++ b/src/components/views/address/SignerAddress.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="tag is-primary has-radius-lg is-medium is-clickable" @click="onClick">
+  <div
+    class="tag is-primary has-radius-lg is-medium is-clickable"
+    @click="onClick"
+  >
     <span class="icon">
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/src/data/network/web3/ethereum/ethereumClient.js
+++ b/src/data/network/web3/ethereum/ethereumClient.js
@@ -27,16 +27,28 @@ class EthereumClient {
     if (window.ethereum) {
       try {
         await window.ethereum.request({ method: "eth_requestAccounts" });
-      } catch(error) {
-        console.log(error)
-        return
+      } catch (error) {
+        if (error.code === -32002) {
+          return {
+            ok: false,
+            msg: 'Unable to connect to your MetaMask wallet. Is it unlocked?'
+          }
+        }
+        else {
+          return {
+            ok: false,
+            msg: error.message
+          }
+        }
       }
     }
 
     this.walletProvider = new ethers.providers.Web3Provider(window.ethereum)
     this.walletSigner = this.walletProvider.getSigner()
 
-    return true
+    return {
+      ok: true
+    }
   }
 
   async getWalletAddress() {
@@ -66,7 +78,7 @@ class EthereumClient {
    */
   getMutableContract(contract) {
     return contract.connect(this.walletSigner)
-  } 
+  }
 }
 
 export default EthereumClient

--- a/src/data/network/web3/ethereum/ethereumClient.js
+++ b/src/data/network/web3/ethereum/ethereumClient.js
@@ -27,6 +27,13 @@ class EthereumClient {
     if (window.ethereum) {
       try {
         await window.ethereum.request({ method: "eth_requestAccounts" });
+
+        this.walletProvider = new ethers.providers.Web3Provider(window.ethereum)
+        this.walletSigner = this.walletProvider.getSigner()
+
+        return {
+          ok: true
+        }
       } catch (error) {
         if (error.code === -32002) {
           return {
@@ -42,20 +49,15 @@ class EthereumClient {
         }
       }
     }
-
-    this.walletProvider = new ethers.providers.Web3Provider(window.ethereum)
-    this.walletSigner = this.walletProvider.getSigner()
-
-    return {
-      ok: true
-    }
   }
 
   async getWalletAddress() {
+    if (!this.walletSigner) await this.syncWallet();
     return this.walletSigner.getAddress()
   }
 
   async getWalletEthBalance() {
+    if (!this.walletSigner) await this.syncWallet();
     return (await this.walletSigner.getBalance()).toString()
   }
 

--- a/src/models/walletState.js
+++ b/src/models/walletState.js
@@ -3,6 +3,16 @@
  * @property {string} address Address of the wallet
  * @property {number} ethBalance Balance of the wallet in ETH
  */
+
+const networks = {
+  'mainnet': '1',
+  'kovan': '42',
+  'ropsten': '3',
+  'rinkeby': '4',
+  'goerli': '5',
+  'arbitrum': '42161'
+}
+
 class WalletState {
   constructor(
     address,
@@ -12,7 +22,8 @@ class WalletState {
     this.address = error ? null : address;
     this.ethBalance = error ? 0 : ethBalance;
     this.error = error;
+    this.chainId = window.ethereum.networkVersion;
   }
 }
 
-export default WalletState
+export { WalletState, networks }

--- a/src/models/walletState.js
+++ b/src/models/walletState.js
@@ -3,13 +3,15 @@
  * @property {string} address Address of the wallet
  * @property {number} ethBalance Balance of the wallet in ETH
  */
- class WalletState {
+class WalletState {
   constructor(
     address,
-    ethBalance
+    ethBalance,
+    error
   ) {
-    this.address = address
-    this.ethBalance = ethBalance
+    this.address = error ? null : address;
+    this.ethBalance = error ? 0 : ethBalance;
+    this.error = error;
   }
 }
 

--- a/src/services/wallet/index.js
+++ b/src/services/wallet/index.js
@@ -5,7 +5,7 @@ import WalletState from "../../models/walletState"
  * Wallet service
  * @property {EthereumClient} client Ethereum client
  */
- class Wallet {
+class Wallet {
   constructor(
     ethereumClient
   ) {
@@ -13,19 +13,16 @@ import WalletState from "../../models/walletState"
   }
 
   async getState() {
-    await this.client.syncWallet()
+    const result = await this.client.syncWallet();
 
-    let values = await Promise.all([
+    if (!result.ok) {
+      console.log(19, result);
+      return new WalletState(null, 0, result);
+    }
+    return new WalletState(
       (await this.client.getWalletAddress()).toLowerCase(),
-      this.client.getWalletEthBalance()
-    ])
-
-    const state = new WalletState(
-      values[0],
-      values[1] / Math.pow(10, 18)
+      this.client.getWalletEthBalance() / Math.pow(10, 18)
     )
-
-    return state
   }
 }
 

--- a/src/services/wallet/index.js
+++ b/src/services/wallet/index.js
@@ -1,5 +1,5 @@
 import EthereumClient from "../../data/network/web3/ethereum/ethereumClient"
-import WalletState from "../../models/walletState"
+import { WalletState } from "../../models/walletState"
 
 /**
  * Wallet service
@@ -20,7 +20,7 @@ class Wallet {
       return new WalletState(null, 0, result);
     }
     return new WalletState(
-      (await this.client.getWalletAddress()).toLowerCase(),
+      (await this.client.getWalletAddress() || '').toLowerCase(),
       this.client.getWalletEthBalance() / Math.pow(10, 18)
     )
   }

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -1,5 +1,5 @@
 import ServiceProvider from "../services/provider"
-import WalletState from "../models/walletState"
+import { networks, WalletState } from "../models/walletState"
 import { MarketOrderType } from "../models/marketOrder"
 import { bigIntMax, bigIntMin } from "../utils/common"
 import router from "../router/index"
@@ -120,9 +120,16 @@ const getters = {
 const actions = {
   async syncWallet(context, params) {
     const walletState = await wallet.getState()
-    console.log(124, walletState);
     if (walletState.error) {
       params.$toast.error(walletState.error.msg)
+    }
+    else {
+      if (walletState.chainId !== networks.rinkeby) {
+        params.$toast.show('Wallet connected, but you seem to be on the wrong network! Switch to Rinkeby in your wallet.')
+      }
+      else {
+        params.$toast.success('Wallet connected!')
+      }
     }
     context.commit("setWallet", walletState)
   },

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -42,6 +42,10 @@ const getters = {
     return state.user.wallet.ethBalance
   },
 
+  walletError(state) {
+    return state.user.wallet.error
+  },
+
   allAssets(state) {
     return state.platform.assets
   },
@@ -114,8 +118,12 @@ const getters = {
 }
 
 const actions = {
-  async syncWallet(context) {
+  async syncWallet(context, params) {
     const walletState = await wallet.getState()
+    console.log(124, walletState);
+    if (walletState.error) {
+      params.$toast.error(walletState.error.msg)
+    }
     context.commit("setWallet", walletState)
   },
 
@@ -207,6 +215,9 @@ const actions = {
 const mutations = {
   setWallet(state, wallet) {
     state.user.wallet = wallet
+    if (wallet.error) {
+      console.log(wallet.error);
+    }
   },
 
   setEthBalance(state, ethBalance) {


### PR DESCRIPTION
We now display an error toast if wallet sync fails for some reason. Wallet sync failing is not unusual, for example if wallet is locked, and we should alert the user in this case.